### PR TITLE
Response error

### DIFF
--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -80,7 +80,7 @@ class API(object):
         response = self.request('POST', endpoint, json=resource)
 
         if 'error' in response:
-            raise CreateResourceError(response.message)
+            raise CreateResourceError(response)
 
         return resource.__class__(self, response)
 


### PR DESCRIPTION
When called, results in stack trace `AttributeError: 'dict' object has
no attribute 'message'`

Just returning the response to the http request is sufficient.