### PR TITLE
Set Allowed Web Origins when creating client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:alpine AS base
 
 RUN apk --no-cache add ca-certificates
 
@@ -7,6 +7,18 @@ WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY moj_analytics /usr/local/lib/python3.6/site-packages/moj_analytics
+COPY moj_analytics /usr/local/lib/python3.7/site-packages/moj_analytics
 COPY resource /opt/resource
 RUN chmod +x /opt/resource/check /opt/resource/in /opt/resource/out
+
+
+FROM base AS test
+
+COPY test.requirements.txt ./
+RUN pip install --no-cache-dir -r test.requirements.txt
+
+COPY tests tests
+RUN pytest
+
+
+FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine AS base
+FROM python:3.7-alpine AS base
 
 RUN apk --no-cache add ca-certificates
 

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -10,6 +10,10 @@ class CreateResourceError(Exception):
     pass
 
 
+class UpdateResourceError(Exception):
+    pass
+
+
 class Auth0(object):
 
     def __init__(self, client_id, client_secret, domain):

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -84,6 +84,16 @@ class API(object):
 
         return resource.__class__(self, response)
 
+    def update(self, resource):
+        endpoint = '{}s'.format(resource.__class__.__name__.lower())
+
+        response = self.request('PATCH', endpoint, json=resource)
+
+        if 'error' in response:
+            raise UpdateResourceError(response.message)
+
+        return resource.__class__(self, response)
+
     def get_all(self, resource_class):
         endpoint = '{}s'.format(resource_class.__name__.lower())
 
@@ -127,6 +137,10 @@ class Resource(dict):
     def __init__(self, api=None, *args, **kwargs):
         super(Resource, self).__init__(*args, **kwargs)
         self.api = api
+
+    def update(self, **overrides):
+        super().update(overrides)
+        return self.api.update(self)
 
 
 class Client(Resource):

--- a/resource/out
+++ b/resource/out
@@ -30,8 +30,9 @@ def create_client(src_dir, source={}, params={}):
     client = auth0.management.get_or_create(Client(
         name=source['app-name'],
         callbacks=[f'{app_url}/callback'],
-        allowed_origins=[app_url],
-        web_origins=[app_url]))
+        allowed_origins=[app_url]))
+
+    client.update(web_origins=[app_url])
 
     client_id = client['client_id']
 

--- a/resource/out
+++ b/resource/out
@@ -30,7 +30,8 @@ def create_client(src_dir, source={}, params={}):
     client = auth0.management.get_or_create(Client(
         name=source['app-name'],
         callbacks=[f'{app_url}/callback'],
-        allowed_origins=[app_url]))
+        allowed_origins=[app_url],
+        web_origins=[app_url]))
 
     client_id = client['client_id']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,10 @@ def given_access_to_the_management_api(auth0, config, responses):
         )
     ))
 
+    responses.add_callback('PATCH', endpoint, json_response(
+        lambda request: Client(**request.json)
+    ))
+
     responses.add_callback('GET', endpoint, json_response(lambda request: [
         Client(name='client1')
     ]))

--- a/tests/test_auth0_client.py
+++ b/tests/test_auth0_client.py
@@ -23,6 +23,16 @@ class TestAuth0Client(object):
 
     @pytest.mark.usefixtures(
         'given_valid_api_client_credentials',
+        'given_access_to_the_management_api',
+    )
+    def test_it_can_update_a_client(self, auth0):
+        client = auth0.management.get_or_create(Client(name='test-client'))
+        client.update(web_origins=['foo'])
+
+        assert client['web_origins'] == ['foo']
+
+    @pytest.mark.usefixtures(
+        'given_valid_api_client_credentials',
         'given_access_to_the_authorization_api',
         'given_a_permission_exists'
     )


### PR DESCRIPTION
Set Auth0 Allowed Web Origins on creating a client (Application)
* Comma-separated list of allowed origins for use with Cross-Origin Authentication and web message response mode
* This may remove spurious CORS error messages