### PR TITLE
Raise exception if Auth0 response status is bad (plus proper logging)

### DIFF
--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -74,7 +74,8 @@ class API(object):
             base_url=self.base_url,
             endpoint=endpoint
         )
-        log.msg("Calling endpoint: {}".format(url))
+        log.msg("Calling endpoint.", url=url, base_url=self.base_url,
+                endpoint=endpoint, method=method)
 
         response = requests.request(
             method,
@@ -90,7 +91,9 @@ class API(object):
         try:
             response.raise_for_status()
         except Exception as ex:
-            log.msg("Auth0 API error.", exc_info=ex)
+            log.msg("Auth0 API error.", exc_info=ex, url=url,
+                    base_url=self.base_url, endpoint=endpoint, method=method,
+                    status=response.status_code, content=response.text)
             raise ex
 
         # No error? Good to go with the JSON payload.

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -113,15 +113,33 @@ class API(object):
     def get(self, resource):
         resources = self.get_all(resource.__class__)
 
+        # DEBUG
+        print(f"DEBUG (ignore): len(resources) = {len(resources)}")
+
         for other in resources:
+            # DEBUG
+            if resource.__class__ == Permission:
+                print(f"DEBUG (ignore): dict(other.items()) = {dict(other.items())}")
 
             if all(pair in other.items() for pair in resource.items()):
                 return other
 
     def get_or_create(self, resource):
+        # DEBUG
+        if resource.__class__ == Permission:
+            print(f"DEBUG (ignore): resource = {resource}")
+
         result = self.get(resource)
 
+        # DEBUG
+        if result.__class__ == Permission:
+            print(f"DEBUG (ignore): result of get(resource) = {result}")
+
+        # DEBUG
+        print(f"DEBUG (ignore): result is None = {result is None}")
         if result is None:
+            # DEBUG
+            print(f"DEBUG (ignore): inside if result is None")
             result = self.create(resource)
 
         return result

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -73,6 +73,8 @@ class API(object):
             json=kwargs.get('json', {})
         )
 
+        response.raise_for_status()
+
         if response.text:
             return response.json()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 auth0-python==3.9.0
+structlog


### PR DESCRIPTION
### What
This PR tweaks the `API.request()` method to check the response status code and raise an exception early on when not a `2xx`. This is done using `request`'s [`#raise_for_status()`](https://requests.readthedocs.io/en/master/user/quickstart/#response-status-codes) method.

This PR also adds some logging using the [`structlog` module](http://www.structlog.org/en/stable/) - thanks to @ntoll for the logging 🏆 .

### Why
Few users got the following error when trying to deploy their Webapp:

```python
[...]
Creating view:app permission ...
Traceback (most recent call last):
  File "/opt/resource/out", line 80, in <module>
    create_client()
  File "/usr/local/lib/python3.7/site-packages/moj_analytics/concourse.py", line 25, in __call__
    response = self.fn(*self.args, **self.kwargs)
  File "/opt/resource/out", line 61, in create_client
    Permission(name='view:app', applicationId=client_id))
  File "/usr/local/lib/python3.7/site-packages/moj_analytics/auth0_client.py", line 123, in get_or_create
    result = self.create(resource)
  File "/usr/local/lib/python3.7/site-packages/moj_analytics/auth0_client.py", line 87, in create
    raise CreateResourceError(response)
moj_analytics.auth0_client.CreateResourceError: {'statusCode': 400, 'error': 'Bad Request', 'message': 'Permission with name "view:app" already exists for this application'}
```

This Concourse resource checks if the Auth0 resources for a webapp are already there before trying to create them. But for some reason it seems like for some application this check doesn't find the existing resource and therefore tries to re-create it. This causes the Auth0 API to respond with a `400 BAD REQUEST`.

### Possible causes
- bad/intermittent response from Auth0 APIs: This would be strange as I would expect logic to raise an exception sooner than when it tries to create a new `Permission`, [e.g. with a `KeyError` of some sort](https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/blob/master/moj_analytics/auth0_client.py#L107). Nevertheless I'm adding `request`s `#raise_for_status()` as it's better to fail earlier if that is, strangely, the case.
- ~Bug in [`API.get()` logic](https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/blob/master/moj_analytics/auth0_client.py#L101-L117)~: This was inspected and it doesn't seem to have any obvious problem.
- ~weird case in repository or app name~: This doesn't seem the case as one of the apps with the problem appear to have a perfectly normal case.
- ~Pagination~: First thought was that the list of existing resources was paginate (this is used to determine if resource exists). This doesn't seem to be the case, or at least not in our case with <200 resources

### 504 error
When raising exceptions on non-2xx response we see the following error coming from the Auth0 Authorization API:

```
504 Server Error: Gateway Timeout for url: https://example.webtask.io/.../api/permissions
```


Related to ticket: https://trello.com/c/I2GozO5D