### PR TITLE
Auth0: Don't pass JSON when making GET requests

### DIFF
--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -77,14 +77,21 @@ class API(object):
         log.msg("Calling endpoint.", url=url, base_url=self.base_url,
                 endpoint=endpoint, method=method)
 
-        response = requests.request(
-            method,
-            url,
-            headers={
+        args = {
+            "headers": {
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer {}'.format(self.access_token),
             },
-            json=kwargs.get('json', {})
+        }
+        # pass "{}" in a GET request appears to cause
+        # a `504 Gateway Timeout`
+        if method != "GET":
+            args["json"] = kwargs.get('json', {})
+
+        response = requests.request(
+            method,
+            url,
+            **args,
         )
 
         # If there's an error, log it then re-raise.


### PR DESCRIPTION
It appears that passing a body with "{}" when making GET requests to
the Authorization API causes it respond with a `504 Gateway Timeout`.

Related to: https://trello.com/c/I2GozO5D