### PR TITLE
Ensure a body and content-length is only sent for POST, PUT and PATCH

### DIFF
--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -77,14 +77,21 @@ class API(object):
         log.msg("Calling endpoint.", url=url, base_url=self.base_url,
                 endpoint=endpoint, method=method)
 
-        response = requests.request(
-            method,
-            url,
-            headers={
+        request_args = {
+            "headers": {
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer {}'.format(self.access_token),
             },
-            json=kwargs.get('json', {})
+        }
+
+        # Only send a payload with POST/PUT or API will respond with 5xx.
+        if method in ("POST", "PUT", "PATCH"):
+            request_args["json"] = kwargs.get("json", {})
+
+        response = requests.request(
+            method,
+            url,
+            **request_args
         )
 
         # If there's an error, log it then re-raise.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,8 @@ def json_response(data, status=200, headers={}):
 
         payload = data
         if callable(data):
-            request.json = json.loads(request.body.decode('utf-8'))
+            if request.body:
+                request.json = json.loads(request.body.decode('utf-8'))
             payload = data(request)
 
         return (status, headers, json.dumps(payload))


### PR DESCRIPTION
This PR supersedes #5.

We ensure that a body and `content-length` header are not allowed for `GET` or `DELETE` requests (we explicitly only allow this to happen for `POST`, `PUT` and `PATCH`). We also updated the unit tests to take this into account.

This should address the `504 Gateway Timeout` errors we were seeing from Auth0.

Related Trello ticket here: https://trello.com/c/I2GozO5D

Created via pairing with @Mohammad-Tari 