### PR TITLE
Handle problematic responses from the Auth0 API

### DIFF
--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -25,6 +25,10 @@ class UpdateResourceError(Exception):
     pass
 
 
+class GetResourceError(Exception):
+    pass
+
+
 class Auth0(object):
 
     def __init__(self, client_id, client_secret, domain):
@@ -116,7 +120,7 @@ class API(object):
 
         response = self.request('POST', endpoint, json=resource)
 
-        if 'error' in response:
+        if 'error' in response or response == {}:
             log.msg("Error creating resource.", response=response)
             raise CreateResourceError(response)
 
@@ -127,7 +131,7 @@ class API(object):
 
         response = self.request('PATCH', endpoint, json=resource)
 
-        if 'error' in response:
+        if 'error' in response or response == {}:
             log.msg("Error updating resource.", response=response)
             raise UpdateResourceError(response)
 
@@ -137,6 +141,10 @@ class API(object):
         endpoint = '{}s'.format(resource_class.__name__.lower())
 
         resources = self.request('GET', endpoint)
+
+        if not resources:
+            log.msg("Error getting resource.", response=response)
+            raise GetResourceError(response)
 
         if endpoint in resources:
             resources = resources[endpoint]


### PR DESCRIPTION
Mo raised [this ticket](https://trello.com/c/9ot65Lmd/637-check-that-auth0-api-calls-are-all-error-checked-correctly-in-concourse-app-pipeline) to ensure all API calls from Auth0 are error checked. He (correctly) noted that there were routes through the code that assumed a good response, but would still be called if a bad response were returned. This has the potential for all sorts of bad things to happen.

This PR follows the guidance of two aspects of the Zen of Python:

* Explicit is better than implicit.
* Errors should never pass silently.

Therefore, all erroneous API responses result in an exception being raised. That's it..!