### PR TITLE
Formatted code with `black` and added GitHub Actions for linting/format checking/testing

### DIFF
--- a/.github/workflows/lint-check-formatting-and-test.yaml
+++ b/.github/workflows/lint-check-formatting-and-test.yaml
@@ -1,0 +1,45 @@
+# Adapted from  GH documentation: https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Lint, check formatting and run tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r dev.requirements.txt
+          pip install -r test.requirements.txt
+
+      - name: Check formatting with black
+        run: |
+          # stop the build if the formatting is off
+          black --check resource/* moj_analytics/* tests/*
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 resource/* moj_analytics/* tests/*  --count --show-source --statistics --ignore=E501,W503
+
+      - name: Test with pytest
+        run: |
+          pytest

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -1,0 +1,2 @@
+black
+flake8

--- a/moj_analytics/auth0_client.py
+++ b/moj_analytics/auth0_client.py
@@ -26,7 +26,6 @@ class UpdateResourceError(Exception):
 
 
 class Auth0(object):
-
     def __init__(self, client_id, client_secret, domain):
         self.client_id = client_id
         self.client_secret = client_secret
@@ -39,48 +38,47 @@ class Auth0(object):
 
         try:
             token = get_token.client_credentials(
-                self.client_id,
-                self.client_secret,
-                audience
+                self.client_id, self.client_secret, audience
             )
 
         except exceptions.Auth0Error as error:
-            log.msg("Access token error.", exc_info=error,
-                    client_id=self.client_id, domain=self.domain)
-            raise AccessTokenError(
-                error,
-                self.client_id,
-                self.domain,
-                audience)
+            log.msg(
+                "Access token error.",
+                exc_info=error,
+                client_id=self.client_id,
+                domain=self.domain,
+            )
+            raise AccessTokenError(error, self.client_id, self.domain, audience)
 
-        return token['access_token']
+        return token["access_token"]
 
     def access(self, api):
-        key = api.__class__.__name__.replace('API', '').lower()
+        key = api.__class__.__name__.replace("API", "").lower()
         api.access_token = self.access_token(api.audience)
         setattr(self, key, api)
 
 
 class API(object):
-
     def __init__(self, base_url, audience=None):
-        self.base_url = base_url.rstrip('/')
+        self.base_url = base_url.rstrip("/")
         self.audience = audience or base_url
         self.access_token = None
         self._token = None
 
     def request(self, method, endpoint, **kwargs):
-        url = '{base_url}/{endpoint}'.format(
+        url = "{base_url}/{endpoint}".format(base_url=self.base_url, endpoint=endpoint)
+        log.msg(
+            "Calling endpoint.",
+            url=url,
             base_url=self.base_url,
-            endpoint=endpoint
+            endpoint=endpoint,
+            method=method,
         )
-        log.msg("Calling endpoint.", url=url, base_url=self.base_url,
-                endpoint=endpoint, method=method)
 
         request_args = {
             "headers": {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer {}'.format(self.access_token),
+                "Content-Type": "application/json",
+                "Authorization": "Bearer {}".format(self.access_token),
             },
         }
 
@@ -88,19 +86,22 @@ class API(object):
         if method in ("POST", "PUT", "PATCH"):
             request_args["json"] = kwargs.get("json", {})
 
-        response = requests.request(
-            method,
-            url,
-            **request_args
-        )
+        response = requests.request(method, url, **request_args)
 
         # If there's an error, log it then re-raise.
         try:
             response.raise_for_status()
         except Exception as ex:
-            log.msg("Auth0 API error.", exc_info=ex, url=url,
-                    base_url=self.base_url, endpoint=endpoint, method=method,
-                    status=response.status_code, content=response.text)
+            log.msg(
+                "Auth0 API error.",
+                exc_info=ex,
+                url=url,
+                base_url=self.base_url,
+                endpoint=endpoint,
+                method=method,
+                status=response.status_code,
+                content=response.text,
+            )
             raise ex
 
         # No error? Good to go with the JSON payload.
@@ -112,31 +113,31 @@ class API(object):
         return {}
 
     def create(self, resource):
-        endpoint = '{}s'.format(resource.__class__.__name__.lower())
+        endpoint = "{}s".format(resource.__class__.__name__.lower())
 
-        response = self.request('POST', endpoint, json=resource)
+        response = self.request("POST", endpoint, json=resource)
 
-        if 'error' in response:
+        if "error" in response:
             log.msg("Error creating resource.", response=response)
             raise CreateResourceError(response)
 
         return resource.__class__(self, response)
 
     def update(self, resource):
-        endpoint = '{}s'.format(resource.__class__.__name__.lower())
+        endpoint = "{}s".format(resource.__class__.__name__.lower())
 
-        response = self.request('PATCH', endpoint, json=resource)
+        response = self.request("PATCH", endpoint, json=resource)
 
-        if 'error' in response:
+        if "error" in response:
             log.msg("Error updating resource.", response=response)
             raise UpdateResourceError(response)
 
         return resource.__class__(self, response)
 
     def get_all(self, resource_class):
-        endpoint = '{}s'.format(resource_class.__name__.lower())
+        endpoint = "{}s".format(resource_class.__name__.lower())
 
-        resources = self.request('GET', endpoint)
+        resources = self.request("GET", endpoint)
 
         if endpoint in resources:
             resources = resources[endpoint]
@@ -160,10 +161,10 @@ class API(object):
 
 
 class ManagementAPI(API):
-
     def __init__(self, domain):
         super(ManagementAPI, self).__init__(
-            'https://{domain}/api/v2/'.format(domain=domain))
+            "https://{domain}/api/v2/".format(domain=domain)
+        )
 
 
 class AuthorizationAPI(API):
@@ -171,7 +172,6 @@ class AuthorizationAPI(API):
 
 
 class Resource(dict):
-
     def __init__(self, api=None, *args, **kwargs):
         super(Resource, self).__init__(*args, **kwargs)
         self.api = api
@@ -182,62 +182,59 @@ class Resource(dict):
 
 
 class Client(Resource):
-
     def __init__(self, api=None, *args, **kwargs):
         super(Client, self).__init__(api, *args, **kwargs)
-        self['app_type'] = 'regular_web'
+        self["app_type"] = "regular_web"
 
     def disable_all_connections(self, ignore=[]):
-        ignore = [connection['id'] for connection in ignore]
+        ignore = [connection["id"] for connection in ignore]
 
         connections = self.api.get_all(Connection)
 
         for connection in connections:
 
-            if connection['id'] in ignore:
+            if connection["id"] in ignore:
                 continue
 
-            if self['client_id'] in connection['enabled_clients']:
+            if self["client_id"] in connection["enabled_clients"]:
                 connection.disable_client(self)
 
 
 class Connection(Resource):
-
     def disable_client(self, client):
 
-        if client['client_id'] in self['enabled_clients']:
-            self['enabled_clients'].remove(client['client_id'])
+        if client["client_id"] in self["enabled_clients"]:
+            self["enabled_clients"].remove(client["client_id"])
 
-            self.api.request('PATCH', 'connections/{id}'.format(**self), json={
-                'enabled_clients': self['enabled_clients']
-            })
+            self.api.request(
+                "PATCH",
+                "connections/{id}".format(**self),
+                json={"enabled_clients": self["enabled_clients"]},
+            )
 
 
 class AuthzResource(Resource):
-
     def __init__(self, api=None, *args, **kwargs):
         super(AuthzResource, self).__init__(api, *args, **kwargs)
 
-        if 'description' not in self and 'name' in self:
-            self['description'] = self['name']
+        if "description" not in self and "name" in self:
+            self["description"] = self["name"]
 
 
 class Permission(AuthzResource):
-
     def __init__(self, api=None, *args, **kwargs):
         super(Permission, self).__init__(api, *args, **kwargs)
-        self['applicationType'] = 'client'
+        self["applicationType"] = "client"
 
 
 class Role(AuthzResource):
-
     def __init__(self, api=None, *args, **kwargs):
         super(Role, self).__init__(api, *args, **kwargs)
-        self['applicationType'] = 'client'
+        self["applicationType"] = "client"
 
     def __getitem__(self, key):
 
-        if key == 'permissions':
+        if key == "permissions":
 
             if not self.__contains__(key):
                 return []
@@ -246,26 +243,29 @@ class Role(AuthzResource):
 
     def add_permission(self, permission):
 
-        if permission['_id'] in self['permissions']:
+        if permission["_id"] in self["permissions"]:
             return
 
-        if 'permissions' not in self:
-            self['permissions'] = []
+        if "permissions" not in self:
+            self["permissions"] = []
 
-        self['permissions'].append(permission['_id'])
+        self["permissions"].append(permission["_id"])
 
-        self.api.request('PUT', 'roles/{_id}'.format(**self), json={
-           'name': self['name'],
-           'description': self['description'],
-           'applicationId': self['applicationId'],
-           'applicationType': self['applicationType'],
-           'permissions': self['permissions'],
-        })
+        self.api.request(
+            "PUT",
+            "roles/{_id}".format(**self),
+            json={
+                "name": self["name"],
+                "description": self["description"],
+                "applicationId": self["applicationId"],
+                "applicationType": self["applicationType"],
+                "permissions": self["permissions"],
+            },
+        )
 
 
 class Group(AuthzResource):
-
     def add_role(self, role):
-        self.api.request('PATCH', 'groups/{_id}/roles'.format(**self), json=[
-            role['_id']
-        ])
+        self.api.request(
+            "PATCH", "groups/{_id}/roles".format(**self), json=[role["_id"]]
+        )

--- a/moj_analytics/concourse.py
+++ b/moj_analytics/concourse.py
@@ -5,37 +5,35 @@ import sys
 
 
 class Resource(object):
-
     def __init__(self, fn):
         self.fn = fn
 
         self.action = os.path.basename(sys.argv[0]).lower()
 
         self.args = []
-        if self.action in ('in', 'out'):
+        if self.action in ("in", "out"):
             self.args.append(sys.argv[1])
 
         self.kwargs = json.loads(sys.stdin.read())
 
-        if 'version' in self.kwargs:
-            self.kwargs['version'] = self.kwargs['version']['ref']
+        if "version" in self.kwargs:
+            self.kwargs["version"] = self.kwargs["version"]["ref"]
 
     def __call__(self):
         with redirect_stdout(sys.stderr):
             response = self.fn(*self.args, **self.kwargs)
 
-        if self.action in ('in', 'out'):
+        if self.action in ("in", "out"):
             version, metadata = response
             response = {
-                'version': { 'ref': version },
+                "version": {"ref": version},
             }
             if metadata:
-                response['metadata'] = [
-                    {'name': name, 'value': value}
-                    for name, value in metadata.items()
+                response["metadata"] = [
+                    {"name": name, "value": value} for name, value in metadata.items()
                 ]
 
-        elif self.action == 'check':
-            response = [{ 'ref': str(v) } for v in response]
+        elif self.action == "check":
+            response = [{"ref": str(v)} for v in response]
 
         print(json.dumps(response))

--- a/resource/check
+++ b/resource/check
@@ -5,8 +5,8 @@ from moj_analytics.concourse import Resource
 
 @Resource
 def check(source={}, version=None):
-    return ['none']
+    return ["none"]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     check()

--- a/resource/in
+++ b/resource/in
@@ -3,47 +3,42 @@
 import json
 import os
 
-from moj_analytics.auth0_client import (
-    Auth0,
-    Client,
-    ManagementAPI,
-    log
-)
+from moj_analytics.auth0_client import Auth0, Client, ManagementAPI, log
 from moj_analytics.concourse import Resource
 
 
 @Resource
 def get_client(dest_dir, source={}, version=None, params={}):
-    auth0 = Auth0(
-        source['client-id'],
-        source['client-secret'],
-        source['domain'])
+    auth0 = Auth0(source["client-id"], source["client-secret"], source["domain"])
 
-    auth0.access(ManagementAPI(source['domain']))
+    auth0.access(ManagementAPI(source["domain"]))
 
     log.msg("Fetching client.", name=source["app-name"])
 
-    client = auth0.management.get(Client(name=source['app-name']))
+    client = auth0.management.get(Client(name=source["app-name"]))
 
-    with open(os.path.join(dest_dir, 'credentials.yaml'), 'w') as outfile:
+    with open(os.path.join(dest_dir, "credentials.yaml"), "w") as outfile:
         try:
             # JSON is a subset of YAML
-            json.dump({
-                'AuthProxy': {
-                    'Auth0': {
-                        'ClientId': client['client_id'],
-                        'ClientSecret': client['client_secret'],
-                        'Domain': source['domain'],
+            json.dump(
+                {
+                    "AuthProxy": {
+                        "Auth0": {
+                            "ClientId": client["client_id"],
+                            "ClientSecret": client["client_secret"],
+                            "Domain": source["domain"],
+                        },
                     },
                 },
-            }, outfile)
+                outfile,
+            )
         except Exception as ex:
             log.msg("Could not write credentials.yaml", exc_info=ex)
             raise ex
 
-    for key in ['client_id', 'client_secret']:
+    for key in ["client_id", "client_secret"]:
         path = os.path.join(dest_dir, key)
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             try:
                 f.write(client[key])
             except Exception as ex:
@@ -52,8 +47,8 @@ def get_client(dest_dir, source={}, version=None, params={}):
 
     log.msg("Done.")
 
-    return 'none', {}
+    return "none", {}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     get_client()

--- a/resource/out
+++ b/resource/out
@@ -10,71 +10,73 @@ from moj_analytics.auth0_client import (
     ManagementAPI,
     Permission,
     Role,
-    log
+    log,
 )
 from moj_analytics.concourse import Resource
 
 
 @Resource
 def create_client(src_dir, source={}, params={}):
-    auth0 = Auth0(
-        source['client-id'],
-        source['client-secret'],
-        source['domain'])
+    auth0 = Auth0(source["client-id"], source["client-secret"], source["domain"])
 
-    auth0.access(ManagementAPI(source['domain']))
+    auth0.access(ManagementAPI(source["domain"]))
 
-    app_url = 'https://{app-name}.{app-domain}'.format(**source)
+    app_url = "https://{app-name}.{app-domain}".format(**source)
 
-    log.msg("Creating client.", name=source["app-name"],
-            callback_url=f"{app_url}/callback")
+    log.msg(
+        "Creating client.", name=source["app-name"], callback_url=f"{app_url}/callback"
+    )
 
-    client = auth0.management.get_or_create(Client(
-        name=source['app-name'],
-        callbacks=[f'{app_url}/callback'],
-        allowed_origins=[app_url]))
+    client = auth0.management.get_or_create(
+        Client(
+            name=source["app-name"],
+            callbacks=[f"{app_url}/callback"],
+            allowed_origins=[app_url],
+        )
+    )
 
     # TODO: This never worked, fix it
     # client.update(web_origins=[app_url])
 
-    client_id = client['client_id']
+    client_id = client["client_id"]
 
     data = {}
-    with open('/tmp/build/put/webapp-source/deploy.json') as input:
+    with open("/tmp/build/put/webapp-source/deploy.json") as input:
         try:
             data = json.load(input)
         except Exception as ex:
             log.msg("Could not parse deploy.json", exc_info=ex)
             raise ex
 
-    connections = data.get('connections', ["email"])
-    auth0_connections = [auth0.management.get(Connection(name=connection))
-                         for connection in connections]
+    connections = data.get("connections", ["email"])
+    auth0_connections = [
+        auth0.management.get(Connection(name=connection)) for connection in connections
+    ]
     log.msg("Setting email connections.", connections=connections)
 
     client.disable_all_connections(ignore=auth0_connections)
 
-    auth0.access(AuthorizationAPI(
-        source['authz-url'],
-        source['authz-audience']))
+    auth0.access(AuthorizationAPI(source["authz-url"], source["authz-audience"]))
 
     log.msg("Creating permission.", name="view:app", application_id=client_id)
     view_app = auth0.authorization.get_or_create(
-        Permission(name='view:app', application_id=client_id))
+        Permission(name="view:app", application_id=client_id)
+    )
 
     log.msg("Creating role.", name="app-viewer", application_id=client_id)
     role = auth0.authorization.get_or_create(
-        Role(name='app-viewer', applicationId=client_id))
+        Role(name="app-viewer", applicationId=client_id)
+    )
     role.add_permission(view_app)
 
     log.msg("Creating group.", name=source["app-name"])
-    group = auth0.authorization.get_or_create(Group(name=source['app-name']))
+    group = auth0.authorization.get_or_create(Group(name=source["app-name"]))
     group.add_role(role)
 
     log.msg("Done.")
 
-    return 'none', {}
+    return "none", {}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     create_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,18 +12,18 @@ from moj_analytics.auth0_client import (
     Group,
     ManagementAPI,
     Permission,
-    Role
+    Role,
 )
 
 
 @pytest.fixture
 def config():
     return {
-        'client_id': 'auth0_client_id',
-        'client_secret': 'auth0_client_secret',
-        'domain': 'example.com',
-        'authz_url': 'https://example.com',
-        'authz_audience': 'urn:auth0-authz-api',
+        "client_id": "auth0_client_id",
+        "client_secret": "auth0_client_secret",
+        "domain": "example.com",
+        "authz_url": "https://example.com",
+        "authz_audience": "urn:auth0-authz-api",
     }
 
 
@@ -49,17 +49,18 @@ def clear_previous(responses, method, url):
 
 
 def json_response(data, status=200, headers={}):
-    headers.setdefault('Content-Type', 'application/json')
+    headers.setdefault("Content-Type", "application/json")
 
     def handle(request):
 
-        assert request.headers['Authorization'] == 'Bearer {token}'.format(
-            token='test-access-token')
+        assert request.headers["Authorization"] == "Bearer {token}".format(
+            token="test-access-token"
+        )
 
         payload = data
         if callable(data):
             if request.body:
-                request.json = json.loads(request.body.decode('utf-8'))
+                request.json = json.loads(request.body.decode("utf-8"))
             payload = data(request)
 
         return (status, headers, json.dumps(payload))
@@ -74,77 +75,81 @@ def state():
 
 @pytest.fixture
 def auth0(config):
-    return Auth0(config['client_id'], config['client_secret'], config['domain'])
+    return Auth0(config["client_id"], config["client_secret"], config["domain"])
 
 
 @pytest.yield_fixture
 def given_valid_api_client_credentials():
 
-    with mock.patch('moj_analytics.auth0_client.authentication.GetToken') as gt:
+    with mock.patch("moj_analytics.auth0_client.authentication.GetToken") as gt:
         gt.return_value.client_credentials.return_value = {
-            'access_token': 'test-access-token'
+            "access_token": "test-access-token"
         }
         yield
 
 
 @pytest.fixture
 def given_access_to_the_management_api(auth0, config, responses):
-    auth0.access(ManagementAPI(config['domain']))
+    auth0.access(ManagementAPI(config["domain"]))
 
-    endpoint = 'https://{domain}/api/v2/clients'.format(**config)
+    endpoint = "https://{domain}/api/v2/clients".format(**config)
 
-    responses.add_callback('POST', endpoint, json_response(
-        lambda request: Client(
-            name=request.json['name'],
-            client_id='new-client-id',
-            client_secret='new-client-secret'
-        )
-    ))
+    responses.add_callback(
+        "POST",
+        endpoint,
+        json_response(
+            lambda request: Client(
+                name=request.json["name"],
+                client_id="new-client-id",
+                client_secret="new-client-secret",
+            )
+        ),
+    )
 
-    responses.add_callback('PATCH', endpoint, json_response(
-        lambda request: Client(**request.json)
-    ))
+    responses.add_callback(
+        "PATCH", endpoint, json_response(lambda request: Client(**request.json))
+    )
 
-    responses.add_callback('GET', endpoint, json_response(lambda request: [
-        Client(name='client1')
-    ]))
+    responses.add_callback(
+        "GET", endpoint, json_response(lambda request: [Client(name="client1")])
+    )
 
 
 @pytest.fixture
 def mock_resources(responses):
-
     def do_mock(base_url, resource_name, data, json_format=None):
 
-        endpoint = '{base_url}/{resource_name}'.format(
-            base_url=base_url,
-            resource_name=resource_name)
+        endpoint = "{base_url}/{resource_name}".format(
+            base_url=base_url, resource_name=resource_name
+        )
 
-        clear_previous(responses, 'GET', endpoint)
+        clear_previous(responses, "GET", endpoint)
 
         for counter, resource in enumerate(data):
-            resource['_id'] = counter
+            resource["_id"] = counter
 
         if json_format is None:
             json_format = identity
 
-        responses.add_callback('GET', endpoint, json_response(
-            json_format(resource_name, data)))
+        responses.add_callback(
+            "GET", endpoint, json_response(json_format(resource_name, data))
+        )
 
-        if resource_name == 'roles':
+        if resource_name == "roles":
 
             for role in data:
                 responses.add_callback(
-                    'PUT',
-                    '{}/{}'.format(endpoint, resource['_id']),
-                    json_response({}))
+                    "PUT", "{}/{}".format(endpoint, resource["_id"]), json_response({})
+                )
 
-        if resource_name == 'groups':
+        if resource_name == "groups":
 
             for group in data:
                 responses.add_callback(
-                    'PATCH',
-                    '{}/{}/roles'.format(endpoint, group['_id']),
-                    json_response({}))
+                    "PATCH",
+                    "{}/{}/roles".format(endpoint, group["_id"]),
+                    json_response({}),
+                )
 
     return do_mock
 
@@ -154,80 +159,85 @@ def identity(data):
 
 
 def authz_format(resource_name, data):
-    return {
-        resource_name: data,
-        'total': len(data)
-    }
+    return {resource_name: data, "total": len(data)}
 
 
-@pytest.fixture(params=[
-    [],
-    [Client(name='client1')],
-    [Client(name='client{}'.format(i)) for i in range(10)]
-])
+@pytest.fixture(
+    params=[
+        [],
+        [Client(name="client1")],
+        [Client(name="client{}".format(i)) for i in range(10)],
+    ]
+)
 def given_a_number_of_clients_exist(request, config, mock_resources, state):
-    mock_resources(config['management_url'], 'clients', request.param)
-    state['clients'] = request.params
+    mock_resources(config["management_url"], "clients", request.param)
+    state["clients"] = request.params
 
 
-@pytest.fixture(params=[
-    [],
-    [Connection(name='connection1')],
-    [Connection(name='connection{}'.format(i)) for i in range(10)]
-])
+@pytest.fixture(
+    params=[
+        [],
+        [Connection(name="connection1")],
+        [Connection(name="connection{}".format(i)) for i in range(10)],
+    ]
+)
 def given_a_number_of_connections_exist(request, config, responses, state):
-    mock_resources(config['management_url'], 'connections', request.param)
-    state['connections'] = request.param
+    mock_resources(config["management_url"], "connections", request.param)
+    state["connections"] = request.param
 
 
 @pytest.fixture
 def given_access_to_the_authorization_api(auth0, config, responses):
-    auth0.access(AuthorizationAPI(
-        config['authz_url'], config['authz_audience']))
+    auth0.access(AuthorizationAPI(config["authz_url"], config["authz_audience"]))
 
-    endpoint = '{authz_url}/permissions'.format(**config)
-    responses.add_callback('POST', endpoint, json_response(lambda request: {
-        'name': request.json['name'],
-        'description': request.json['description'],
-    }))
-    responses.add_callback('GET', endpoint, json_response({
-        'permissions': [],
-        'total': 0
-    }))
+    endpoint = "{authz_url}/permissions".format(**config)
+    responses.add_callback(
+        "POST",
+        endpoint,
+        json_response(
+            lambda request: {
+                "name": request.json["name"],
+                "description": request.json["description"],
+            }
+        ),
+    )
+    responses.add_callback(
+        "GET", endpoint, json_response({"permissions": [], "total": 0})
+    )
 
-    endpoint = '{authz_url}/roles'.format(**config)
-    responses.add_callback('GET', endpoint, json_response({
-        'roles': [],
-        'total': 0
-    }))
-    responses.add_callback('POST', endpoint, json_response(lambda request: {
-        'name': request.json['name'],
-        'description': request.json['description']
-    }))
+    endpoint = "{authz_url}/roles".format(**config)
+    responses.add_callback("GET", endpoint, json_response({"roles": [], "total": 0}))
+    responses.add_callback(
+        "POST",
+        endpoint,
+        json_response(
+            lambda request: {
+                "name": request.json["name"],
+                "description": request.json["description"],
+            }
+        ),
+    )
 
-    endpoint = '{authz_url}/groups'.format(**config)
-    responses.add_callback('GET', endpoint, json_response({
-        'roles': [],
-        'total': 0
-    }))
+    endpoint = "{authz_url}/groups".format(**config)
+    responses.add_callback("GET", endpoint, json_response({"roles": [], "total": 0}))
 
 
 @pytest.fixture
 def given_a_group_exists(request, config, mock_resources, state):
-    data = [Group(name='group1')]
-    mock_resources(config['authz_url'], 'groups', data, authz_format)
-    state['groups'] = data
+    data = [Group(name="group1")]
+    mock_resources(config["authz_url"], "groups", data, authz_format)
+    state["groups"] = data
 
 
 @pytest.fixture
 def given_a_permission_exists(request, config, mock_resources, state):
-    data = [Permission(name='perm1', applicationId='app1')]
-    mock_resources(config['authz_url'], 'permissions', data, authz_format)
-    state['permissions'] = data
+    data = [Permission(name="perm1", applicationId="app1")]
+    mock_resources(config["authz_url"], "permissions", data, authz_format)
+    state["permissions"] = data
 
 
 @pytest.fixture
 def given_a_role_exists(request, config, mock_resources, state):
-    data = [Role(name='role1', applicationId='app1')]
-    mock_resources(config['authz_url'], 'roles', data, authz_format)
-    state['roles'] = data
+    data = [Role(name="role1", applicationId="app1")]
+    mock_resources(config["authz_url"], "roles", data, authz_format)
+    state["roles"] = data

--- a/tests/test_auth0_client.py
+++ b/tests/test_auth0_client.py
@@ -1,110 +1,101 @@
 import pytest
 
-from moj_analytics.auth0_client import (
-    Client,
-    Group,
-    Permission,
-    Role
-)
+from moj_analytics.auth0_client import Client, Group, Permission, Role
 
 
 class TestAuth0Client(object):
-
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_management_api',
+        "given_valid_api_client_credentials", "given_access_to_the_management_api",
     )
     def test_it_can_create_a_client(self, auth0):
 
-        client = auth0.management.get_or_create(Client(name='test-client'))
+        client = auth0.management.get_or_create(Client(name="test-client"))
 
-        assert client['client_id'] == 'new-client-id'
-        assert client['client_secret'] == 'new-client-secret'
+        assert client["client_id"] == "new-client-id"
+        assert client["client_secret"] == "new-client-secret"
 
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_management_api',
+        "given_valid_api_client_credentials", "given_access_to_the_management_api",
     )
     def test_it_can_update_a_client(self, auth0):
-        client = auth0.management.get_or_create(Client(name='test-client'))
-        client.update(web_origins=['foo'])
+        client = auth0.management.get_or_create(Client(name="test-client"))
+        client.update(web_origins=["foo"])
 
-        assert client['web_origins'] == ['foo']
+        assert client["web_origins"] == ["foo"]
 
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_authorization_api',
-        'given_a_permission_exists'
+        "given_valid_api_client_credentials",
+        "given_access_to_the_authorization_api",
+        "given_a_permission_exists",
     )
     def test_it_can_get_a_permission(self, auth0, responses, state):
 
-        permission = auth0.authorization.get(Permission(
-            name='perm1',
-            applicationId='app1'
-        ))
+        permission = auth0.authorization.get(
+            Permission(name="perm1", applicationId="app1")
+        )
 
-        if len(state['permissions']) == 0:
+        if len(state["permissions"]) == 0:
             assert permission is None
 
         else:
             assert permission
 
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_authorization_api'
+        "given_valid_api_client_credentials", "given_access_to_the_authorization_api"
     )
     def test_it_can_create_a_permission(self, auth0):
 
-        permission = auth0.authorization.get_or_create(Permission(
-            name='view:app',
-            applicationId='new-client-id'
-        ))
+        permission = auth0.authorization.get_or_create(
+            Permission(name="view:app", applicationId="new-client-id")
+        )
 
-        assert permission['description'] == 'view:app'
+        assert permission["description"] == "view:app"
 
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_authorization_api',
+        "given_valid_api_client_credentials", "given_access_to_the_authorization_api",
     )
     def test_it_can_create_a_role(self, auth0):
 
         role = auth0.authorization.create(
-            Role(name='role1', applicationId='new-client-id'))
+            Role(name="role1", applicationId="new-client-id")
+        )
 
-        assert role['description'] == 'role1'
+        assert role["description"] == "role1"
 
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_authorization_api',
-        'given_a_role_exists',
-        'given_a_permission_exists'
+        "given_valid_api_client_credentials",
+        "given_access_to_the_authorization_api",
+        "given_a_role_exists",
+        "given_a_permission_exists",
     )
     def test_it_can_add_a_permission_to_a_role(self, auth0):
 
-        role = auth0.authorization.get(Role(name='role1', applicationId='app1'))
+        role = auth0.authorization.get(Role(name="role1", applicationId="app1"))
         permission = auth0.authorization.get(
-            Permission(name='perm1', applicationId='app1'))
+            Permission(name="perm1", applicationId="app1")
+        )
 
         role.add_permission(permission)
 
-        assert permission['_id'] in role['permissions']
+        assert permission["_id"] in role["permissions"]
 
     @pytest.mark.usefixtures(
-        'given_valid_api_client_credentials',
-        'given_access_to_the_authorization_api',
-        'given_a_group_exists',
-        'given_a_role_exists'
+        "given_valid_api_client_credentials",
+        "given_access_to_the_authorization_api",
+        "given_a_group_exists",
+        "given_a_role_exists",
     )
     def test_it_can_add_a_role_to_a_group(self, auth0, responses):
 
-        group = auth0.authorization.get(Group(name='group1'))
-        role = auth0.authorization.get(Role(name='role1', applicationId='app1'))
+        group = auth0.authorization.get(Group(name="group1"))
+        role = auth0.authorization.get(Role(name="role1", applicationId="app1"))
 
         group.add_role(role)
 
         calls = [
             call
             for call in responses.calls
-            if call.request.method == 'PATCH'
-            and call.request.url.endswith('groups/{_id}/roles'.format(**group))]
+            if call.request.method == "PATCH"
+            and call.request.url.endswith("groups/{_id}/roles".format(**group))
+        ]
         assert len(calls) == 1


### PR DESCRIPTION
- [formatted code with `black`](https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/pull/10/commits/13fb2dbcfc89dfbf63b035a70d545d694c4d73f6)
- [added GitHub Actions' workflow to lint using flake8, check formatting using `black` and run tests automatically](https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/pull/10/commits/b72587b1de071bb9bf1749ff6597892950bb08a8)